### PR TITLE
move lombok to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
             <artifactId>cartridge-driver</artifactId>
             <version>${driver.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.14</version>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -131,6 +126,12 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.14</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -147,11 +148,6 @@
                         <phase>process-test-resources</phase>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.12.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Since lombok is used in tests only - moving it to tests scope. Also, it seems that lombok-maven-plugin is only configured with version but not used (usually used for delomboking?), so removing it.

Solves #53