### PR TITLE
Fix truncate

### DIFF
--- a/src/main/java/org/springframework/data/tarantool/core/BaseTarantoolTemplate.java
+++ b/src/main/java/org/springframework/data/tarantool/core/BaseTarantoolTemplate.java
@@ -186,17 +186,7 @@ abstract class BaseTarantoolTemplate implements TarantoolOperations {
 
     @Override
     public void truncate(String spaceName) {
-        //FIXME implement truncate in cartridge-driver and remove this temporary hack
-        if (tarantoolClient instanceof ProxyTarantoolClient) {
-            boolean result = executeSync(() -> tarantoolClient.callForSingleResult(
-                    "crud.truncate",
-                    Collections.singletonList(spaceName), Boolean.class));
-            if (!result) {
-                throw new TarantoolSpaceOperationException("CRUD failed to truncate space " + spaceName);
-            }
-        } else {
-            throw new UnsupportedOperationException("Truncate operation is not supported in the driver yet");
-        }
+        executeSync(() -> tarantoolClient.space(spaceName).truncate());
     }
 
     @Override

--- a/src/test/java/org/springframework/data/tarantool/config/TarantoolConfigurationSupportTest.java
+++ b/src/test/java/org/springframework/data/tarantool/config/TarantoolConfigurationSupportTest.java
@@ -9,7 +9,6 @@ import org.springframework.data.tarantool.BaseIntegrationTest;
 import org.springframework.data.tarantool.TestConfig;
 import org.springframework.data.tarantool.core.mapping.Tuple;
 import org.springframework.data.tarantool.entities.ObjectWithoutTuple;
-import org.springframework.data.tarantool.repository.RepositoryWithoutTupleAnnotationOnEntity;
 
 import java.util.Set;
 
@@ -24,9 +23,6 @@ class TarantoolConfigurationSupportTest extends BaseIntegrationTest {
 
     @Autowired
     private TestConfig testConfig;
-
-    @Autowired
-    private RepositoryWithoutTupleAnnotationOnEntity repositoryWithoutTupleAnnotationOnEntity;
 
     @Test
     @SneakyThrows

--- a/src/test/java/org/springframework/data/tarantool/repository/support/RepositoryIntegrationTest.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/support/RepositoryIntegrationTest.java
@@ -1,7 +1,7 @@
 package org.springframework.data.tarantool.repository.support;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,14 +35,24 @@ class RepositoryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private TestFloatRepository testFloatRepository;
 
-    @BeforeAll
-    public static void setUp() throws Exception {
-        tarantoolContainer.executeScript("test_setup.lua").get();
+    @BeforeEach
+    public void setUp() {
+        Book donQuixote = Book.builder()
+                .id(1).uniqueKey("a1").name("Don Quixote").author("Miguel de Cervantes").year(1605).build();
+        Book theGreatGatsby = Book.builder()
+                .id(2).uniqueKey("a2").name("The Great Gatsby").author("F. Scott Fitzgerald").year(1925).build();
+        Book warAndPeace = Book.builder()
+                .id(3).uniqueKey("a3").name("War and Peace").author("Leo Tolstoy").year(1869).build();
+        bookRepository.save(donQuixote);
+        bookRepository.save(theGreatGatsby);
+        bookRepository.save(warAndPeace);
     }
 
-    @AfterAll
-    public static void tearDown() throws Exception {
-        tarantoolContainer.executeScript("test_teardown.lua").get();
+    @AfterEach
+    public void tearDown() {
+        bookRepository.deleteAll();
+        testDoubleRepository.deleteAll();
+        testFloatRepository.deleteAll();
     }
 
     @Test
@@ -75,6 +85,15 @@ class RepositoryIntegrationTest extends BaseIntegrationTest {
         Book newBook = bookRepository.save(book);
         bookRepository.delete(newBook);
         assertThat(bookRepository.existsById(6)).isFalse();
+    }
+
+    @Test
+    public void test_deleteAll() {
+        List<Book> books = (List<Book>) bookRepository.findAll();
+        assertEquals(3, books.size());
+        bookRepository.deleteAll();
+        books = (List<Book>) bookRepository.findAll();
+        assertEquals(0, books.size());
     }
 
     @Test

--- a/src/test/resources/cartridge/app/roles/api_storage.lua
+++ b/src/test/resources/cartridge/app/roles/api_storage.lua
@@ -164,6 +164,8 @@ local function init_space()
         unique = false,
         if_not_exists = true,
     })
+
+    box.schema.space.create("dropped_space")
 end
 
 local function storage_get_space_format()
@@ -205,6 +207,10 @@ local function find_book_by_book(book)
               :totable()
 end
 
+local function drop_space(space_name)
+    return box.space[space_name]:drop()
+end
+
 local function init(opts)
     if opts.is_master then
         init_space()
@@ -218,6 +224,7 @@ local function init(opts)
     rawset(_G, 'find_customer_by_book', find_customer_by_book)
     rawset(_G, 'find_book_by_address', find_book_by_address)
     rawset(_G, 'find_book_by_book', find_book_by_book)
+    rawset(_G, 'drop_space', drop_space)
     rawset(_G, 'ddl', { get_schema = require('ddl').get_schema })
 
     return true


### PR DESCRIPTION
We removed the temporary hack and use native driver truncate,
which was implemented in cartridge-java (see [1]).

[1]: https://github.com/tarantool/cartridge-java/pull/120

Closes #70