### PR TITLE
Change file name for integration tests

### DIFF
--- a/src/test/java/org/springframework/data/tarantool/repository/support/IntegrationWithoutTuplesTest.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/support/IntegrationWithoutTuplesTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Oleg Kuznetsov
  */
 @Tag("integration")
-public class IntegrationTestWithoutTuples extends BaseIntegrationTest {
+public class IntegrationWithoutTuplesTest extends BaseIntegrationTest {
 
     @Autowired
     private SampleUserRepository sampleUserRepository;


### PR DESCRIPTION
These tests did not run because their postfix does not contain the word test