### PR TITLE
Allow methods without Query in Repository

### DIFF
--- a/src/main/java/org/springframework/data/tarantool/core/TarantoolTemplate.java
+++ b/src/main/java/org/springframework/data/tarantool/core/TarantoolTemplate.java
@@ -90,6 +90,9 @@ public class TarantoolTemplate extends BaseTarantoolTemplate {
 
     @Override
     public <T> T callForObject(String functionName, List<?> parameters, ValueConverter<Value, T> entityConverter) {
+        Assert.hasText(functionName, "Function name must not be null or empty!");
+        Assert.notNull(parameters, "Parameters must not be null!");
+        Assert.notNull(entityConverter, "Entity converter must not be null!");
         return executeSync(() -> tarantoolClient.callForSingleResult(
                 functionName, mapParameters(parameters), getMessagePackMapper(), entityConverter)
         );
@@ -97,6 +100,9 @@ public class TarantoolTemplate extends BaseTarantoolTemplate {
 
     @Override
     public <T> T callForObject(String functionName, List<?> parameters, Class<T> entityClass) {
+        Assert.hasText(functionName, "Function name must not be null or empty!");
+        Assert.notNull(parameters, "Parameters must not be null!");
+        Assert.notNull(entityClass, "Entity class must not be null!");
         return executeSync(
                 () -> tarantoolClient.callForSingleResult(functionName, mapParameters(parameters), entityClass)
                         .thenApply((value) -> value == null ? null : mapToEntity(value, entityClass))
@@ -138,6 +144,10 @@ public class TarantoolTemplate extends BaseTarantoolTemplate {
 
     @Override
     public <T> T callForObject(String functionName, List<?> parameters, Class<T> entityClass, String spaceName) {
+        Assert.hasText(functionName, "Function name must not be null or empty!");
+        Assert.notNull(parameters, "Parameters must not be null!");
+        Assert.notNull(entityClass, "Entity class must not be null!");
+
         Optional<TarantoolSpaceMetadata> spaceMetadata = tarantoolClient.metadata().getSpaceByName(spaceName);
 
         CallResultMapper<T, SingleValueCallResult<T>> resultMapper
@@ -160,6 +170,9 @@ public class TarantoolTemplate extends BaseTarantoolTemplate {
     @Override
     public <T> List<T> callForObjectList(String functionName, List<?> parameters,
                                          Class<T> entityClass, String spaceName) {
+        Assert.hasText(functionName, "Function name must not be null or empty!");
+        Assert.notNull(parameters, "Parameters must not be null!");
+        Assert.notNull(entityClass, "Entity class must not be null!");
         Optional<TarantoolSpaceMetadata> spaceMetadata = tarantoolClient.metadata().getSpaceByName(spaceName);
 
         CallResultMapper<T, SingleValueCallResult<T>> resultMapper
@@ -190,6 +203,9 @@ public class TarantoolTemplate extends BaseTarantoolTemplate {
 
     @Override
     public <T> List<T> callForObjectList(String functionName, List<?> parameters, Class<T> entityClass) {
+        Assert.hasText(functionName, "Function name must not be null or empty!");
+        Assert.notNull(parameters, "Parameters must not be null!");
+        Assert.notNull(entityClass, "Entity class must not be null!");
         return executeSync(() -> tarantoolClient.callForSingleResult(functionName,
                 mapParameters(parameters), getMessagePackMapper(), getListValueConverter(entityClass))
         );

--- a/src/main/java/org/springframework/data/tarantool/core/query/TarantoolQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/tarantool/core/query/TarantoolQueryLookupStrategy.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
 import org.springframework.data.repository.query.QueryMethodEvaluationContextProvider;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.tarantool.core.TarantoolOperations;
+import org.springframework.data.tarantool.repository.Query;
 import org.springframework.data.tarantool.repository.TarantoolSerializationType;
 import org.springframework.data.tarantool.repository.config.TarantoolRepositoryOperationsMapping;
 
@@ -37,15 +38,10 @@ public class TarantoolQueryLookupStrategy implements QueryLookupStrategy {
 
         TarantoolQueryMethod queryMethod = new TarantoolQueryMethod(method, metadata, projectionFactory);
 
-        if (isOutputExpectTuple(queryMethod)) {
+        Query query = queryMethod.getQueryAnnotation();
+        if (query != null && TarantoolSerializationType.TUPLE.equals(query.output())) {
             return new TarantoolTupleRepositoryQuery(operations, queryMethod);
         }
-
         return new TarantoolObjectRepositoryQuery(operations, queryMethod);
-    }
-
-    private boolean isOutputExpectTuple(TarantoolQueryMethod method) {
-        TarantoolSerializationType output = method.getQueryOutputType();
-        return output.equals(TarantoolSerializationType.TUPLE);
     }
 }

--- a/src/main/java/org/springframework/data/tarantool/core/query/TarantoolQueryMethod.java
+++ b/src/main/java/org/springframework/data/tarantool/core/query/TarantoolQueryMethod.java
@@ -5,7 +5,6 @@ import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.tarantool.repository.Query;
-import org.springframework.data.tarantool.repository.TarantoolSerializationType;
 
 import java.lang.reflect.Method;
 
@@ -45,20 +44,14 @@ public class TarantoolQueryMethod extends QueryMethod {
     }
 
     /**
-     * Returns the response structure that the connector will expect from Tarantool specified in Query annotation
-     *
-     * @return expected output structure
-     */
-    public TarantoolSerializationType getQueryOutputType() {
-        return getQueryAnnotation().output();
-    }
-
-    /**
      * Return the callable function name specified in Query annotation
      *
      * @return API function name
      */
     public String getQueryFunctionName() {
+        if (getQueryAnnotation() == null) {
+            return null;
+        }
         return getQueryAnnotation().function();
     }
 }

--- a/src/test/java/org/springframework/data/tarantool/entities/Book.java
+++ b/src/test/java/org/springframework/data/tarantool/entities/Book.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.tarantool.core.mapping.Field;
 import org.springframework.data.tarantool.core.mapping.Tuple;
+import org.springframework.data.tarantool.repository.inheritance.AbstractEntity;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.List;
 @Data
 @Builder
 @Tuple("test_space")
-public class Book {
+public class Book extends AbstractEntity {
     @Id
     private Integer id;
 

--- a/src/test/java/org/springframework/data/tarantool/repository/inheritance/AbstractEntity.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/inheritance/AbstractEntity.java
@@ -1,0 +1,4 @@
+package org.springframework.data.tarantool.repository.inheritance;
+
+public abstract class AbstractEntity {
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomBookRepository.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomBookRepository.java
@@ -1,0 +1,10 @@
+package org.springframework.data.tarantool.repository.inheritance;
+
+import org.springframework.data.tarantool.entities.Book;
+
+public interface CustomBookRepository extends CustomCrudRepository<Book, Integer> {
+    @Override
+    default String spaceName() {
+        return "test_space";
+    }
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomCrudRepository.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomCrudRepository.java
@@ -1,0 +1,24 @@
+package org.springframework.data.tarantool.repository.inheritance;
+
+import org.springframework.data.tarantool.repository.Query;
+import org.springframework.data.tarantool.repository.TarantoolRepository;
+import org.springframework.data.tarantool.repository.TarantoolSerializationType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomCrudRepository<T extends AbstractEntity, ID> extends TarantoolRepository<T, ID> {
+
+    String spaceName();
+
+    default Optional<List<T>> find(String operator, String indexOrField, Object value) {
+        List<List<?>> conditions = Collections.singletonList(
+                Arrays.asList(operator, indexOrField, value));
+        return select(spaceName(), conditions);
+    }
+
+    @Query(function = "crud.select", output = TarantoolSerializationType.TUPLE)
+    Optional<List<T>> select(String spaceName, List<List<?>> conditions);
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomTestRepository.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/inheritance/CustomTestRepository.java
@@ -1,0 +1,10 @@
+package org.springframework.data.tarantool.repository.inheritance;
+
+import org.springframework.data.tarantool.entities.Book;
+import org.springframework.data.tarantool.repository.Query;
+
+public interface CustomTestRepository extends CustomCrudRepository<Book, Integer> {
+
+    @Query(function = "returning_string")
+    String getSampleString();
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/inheritance/MethodsWithoutQueryRepository.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/inheritance/MethodsWithoutQueryRepository.java
@@ -1,0 +1,17 @@
+package org.springframework.data.tarantool.repository.inheritance;
+
+import org.springframework.data.tarantool.entities.Book;
+import org.springframework.data.tarantool.repository.TarantoolRepository;
+
+import java.util.List;
+
+public interface MethodsWithoutQueryRepository<T extends AbstractEntity, ID> extends TarantoolRepository<T, ID> {
+
+    String getString();
+
+    List<String> getStringList();
+
+    Book getBook();
+
+    List<Book> getBookList();
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/support/InheritanceIntegrationTest.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/support/InheritanceIntegrationTest.java
@@ -1,0 +1,76 @@
+package org.springframework.data.tarantool.repository.support;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.tarantool.BaseIntegrationTest;
+import org.springframework.data.tarantool.entities.Book;
+import org.springframework.data.tarantool.repository.inheritance.CustomBookRepository;
+import org.springframework.data.tarantool.repository.inheritance.CustomCrudRepository;
+import org.springframework.data.tarantool.repository.inheritance.CustomTestRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Artyom Dubinin
+ */
+@Tag("integration")
+class InheritanceIntegrationTest extends BaseIntegrationTest {
+    @Autowired
+    private CustomBookRepository customBookRepository;
+
+    @Autowired
+    private CustomCrudRepository customCrudRepository;
+
+    @Autowired
+    private CustomTestRepository customTestRepository;
+
+    @BeforeEach
+    public void setUp() {
+        Book donQuixote = Book.builder()
+                .id(1).uniqueKey("a1").name("Don Quixote").author("Miguel de Cervantes").year(1605).build();
+        Book theGreatGatsby = Book.builder()
+                .id(2).uniqueKey("a2").name("The Great Gatsby").author("F. Scott Fitzgerald").year(1925).build();
+        Book warAndPeace = Book.builder()
+                .id(3).uniqueKey("a3").name("War and Peace").author("Leo Tolstoy").year(1869).build();
+        customBookRepository.save(donQuixote);
+        customBookRepository.save(theGreatGatsby);
+        customBookRepository.save(warAndPeace);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        customBookRepository.deleteAll();
+    }
+
+    @Test
+    public void test_customCustomCrudFind_shouldCompleteCorrectly_withNonQueriesMethods() {
+        Optional<Book> firstBook = customBookRepository.findById(1);
+        assertTrue(firstBook.isPresent());
+
+        Optional<List<Book>> otherTwoBook = customBookRepository.find(">", "id", 1);
+        assertTrue(otherTwoBook.isPresent());
+        assertEquals(2, otherTwoBook.get().size());
+    }
+
+    @Test
+    public void test_nonQueryMethod_shouldReturnSampleString() {
+        final String sampleString = customTestRepository.getSampleString();
+        
+        assertEquals("test string", sampleString);
+    }
+
+    @Test
+    public void test_methodWithoutQuery_shouldThrowException() {
+        IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> customCrudRepository.spaceName());
+        assertTrue(exception.getMessage().contains("Function name must not be null or empty!"));
+    }
+}

--- a/src/test/java/org/springframework/data/tarantool/repository/support/MethodsWithoutQueryIntegrationTest.java
+++ b/src/test/java/org/springframework/data/tarantool/repository/support/MethodsWithoutQueryIntegrationTest.java
@@ -1,0 +1,48 @@
+package org.springframework.data.tarantool.repository.support;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.tarantool.BaseIntegrationTest;
+import org.springframework.data.tarantool.repository.inheritance.MethodsWithoutQueryRepository;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Artyom Dubinin
+ */
+@Tag("integration")
+class MethodsWithoutQueryIntegrationTest extends BaseIntegrationTest {
+    @Autowired
+    private MethodsWithoutQueryRepository methodsWithoutQueriesRepository;
+
+    @Test
+    public void test_methodWithoutQuery_shouldThrowException_ifCallForObjectWithoutSpaceName() {
+        IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> methodsWithoutQueriesRepository.getString());
+        assertTrue(exception.getMessage().contains("Function name must not be null or empty!"));
+    }
+
+    @Test
+    public void test_methodWithoutQuery_shouldThrowException_ifCallForObjectWithSpaceName() {
+        IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> methodsWithoutQueriesRepository.getBook());
+        assertTrue(exception.getMessage().contains("Function name must not be null or empty!"));
+    }
+
+    @Test
+    public void test_methodWithoutQuery_shouldThrowException_ifCallForObjectListWithoutSpaceName() {
+        IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> methodsWithoutQueriesRepository.getStringList());
+        assertTrue(exception.getMessage().contains("Function name must not be null or empty!"));
+    }
+
+    @Test
+    public void test_methodWithoutQuery_shouldThrowException_ifCallForObjectListWithSpaceName() {
+        IllegalArgumentException exception
+                = assertThrows(IllegalArgumentException.class, () -> methodsWithoutQueriesRepository.getBookList());
+        assertTrue(exception.getMessage().contains("Function name must not be null or empty!"));
+    }
+
+}


### PR DESCRIPTION
We returned the logic that was in 0.4.2. But removed the ability to create an NPE exception, which was when calling a method that did not have the Query annotation.

Closes #94