### PR TITLE
Bump spring-data-commons and test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## [Unreleased]
 
-## [0.5.2] - 2022-10-27
+## [0.5.2] - 2022-10-31
 
 ### Security
 - Bump cartridge-java version to 0.9.1 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
-- Bump spring to 5.3.23.RELEASE ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
-- Bump spring-boot to 2.6.3 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
+- Bump testcontainers-java-tarantool to 0.5.1 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
+- Bump spring-data-commons to 2.7.3 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
+- Bump spring to 5.3.23 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
+- Bump logback-classic to 1.2.9 ([#113](https://github.com/tarantool/cartridge-springdata/issues/113))
 
 ## [0.5.1] - 2022-05-20
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
 
     <properties>
         <spring.version>5.3.23</spring.version>
-        <spring-boot.version>2.6.3</spring-boot.version>
+        <spring-boot.version>2.7.3</spring-boot.version>
         <driver.version>0.9.1</driver.version>
-        <testcontainers.version>0.5.0</testcontainers.version>
+        <testcontainers.version>0.5.1</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logging.config>${project.basedir}/src/test/resources/logback-test.xml</logging.config>
@@ -73,11 +73,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
@@ -109,13 +104,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>1.17.4</version>
+            <version>1.2.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump spring-data-commons to 2.7.3
Bump testcontainers-java-tarantool to 0.5.1
Bump logback-classic to 1.2.9

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Needed for #113
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->