### PR TITLE
Fix naming for Tarantool threads

### DIFF
--- a/src/main/java/org/springframework/data/tarantool/config/AbstractTarantoolDataConfiguration.java
+++ b/src/main/java/org/springframework/data/tarantool/config/AbstractTarantoolDataConfiguration.java
@@ -248,7 +248,7 @@ public abstract class AbstractTarantoolDataConfiguration extends TarantoolConfig
         @Override
         public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
             ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-            worker.setName("TarantoolTemplateQueryExecutor-" + id);
+            worker.setName("TarantoolTemplateQueryExecutor-" + id.incrementAndGet());
             return worker;
         }
     }


### PR DESCRIPTION
Each created thread should have unique name instead constant value.

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->